### PR TITLE
use traditional values: broken 8, unbroken 7

### DIFF
--- a/src/line.rs
+++ b/src/line.rs
@@ -12,8 +12,8 @@ use crate::coin::Coin;
 #[derive(Debug, Clone)]
 pub enum Line {
     BrokenChanging,
-    Broken,
     Unbroken,
+    Broken,
     UnbrokenChanging,
 }
 
@@ -21,8 +21,8 @@ impl Line {
     pub fn from_usize(n: usize) -> Self {
         match n {
             6 => Line::BrokenChanging,
-            7 => Line::Broken,
-            8 => Line::Unbroken,
+            7 => Line::Unbroken,
+            8 => Line::Broken,
             9 => Line::UnbrokenChanging,
             _ => unreachable!(),
         }
@@ -40,8 +40,8 @@ impl Line {
 
         match toss_total {
             6 => Line::BrokenChanging,
-            7 => Line::Broken,
-            8 => Line::Unbroken,
+            7 => Line::Unbroken,
+            8 => Line::Broken,
             9 => Line::UnbrokenChanging,
             _ => unreachable!(),
         }
@@ -71,8 +71,8 @@ impl Line {
         use crate::symbols::big_line::*;
         match self {
             BrokenChanging => print!("{}", BIG_BROKEN_CHANGING),
-            Broken => print!("{}", BIG_BROKEN),
             Unbroken => print!("{}", BIG_UNBROKEN),
+            Broken => print!("{}", BIG_BROKEN),
             UnbrokenChanging => print!("{}", BIG_UNBROKEN_CHANGING),
         };
     }
@@ -90,8 +90,8 @@ impl Display for Line {
         use self::Line::*;
         let line_string = match self {
             BrokenChanging => "-X-",
-            Broken => "- -",
             Unbroken => "---",
+            Broken => "- -",
             UnbrokenChanging => "-O-",
         };
         write!(f, "{}", line_string)
@@ -103,8 +103,8 @@ impl Distribution<Line> for Standard {
     fn sample<R: Rng + ?Sized>(&self, rng: &mut R) -> Line {
         match rng.gen_range(6, 10) {
             6 => Line::BrokenChanging,
-            7 => Line::Broken,
-            8 => Line::Unbroken,
+            7 => Line::Unbroken,
+            8 => Line::Broken,
             9 => Line::UnbrokenChanging,
             _ => unreachable!(),
         }


### PR DESCRIPTION
Gratitude for making this library available!

After a few coin casts I noticed a discrepancy between the results this lib returns to the CLI and what I arrived at on paper. I think the discrepancy is caused by the values assigned to Unbroken (young yang) and Broken (young yin) lines in `lines.rs`.

I checked a number of sources to determine the proper or at least most common values for these lines. Most follow those described in the [I Ching Divination Wikipedia entry](https://www.wikiwand.com/en/I_Ching_divination):
"(6, 7, 8, or 9, corresponding to old yin, young yang, young yin, and old yang, respectively)"

Seeing the hànzì characters for these numbers helped it make perfect sense: "In the hexagrams, broken lines were used as shorthand for the numbers 6 (六) and 8 (八), and solid lines were shorthand for values of 7 (七) and 9 (九)."

So I flipped the values where I could find them in the library, did a build, tested it out, and submitted this pull request :)