### PR TITLE
draw lines from bottom up when self-casting

### DIFF
--- a/src/hexagram.rs
+++ b/src/hexagram.rs
@@ -51,6 +51,7 @@ impl Hexagram {
 
         let mut trigrams = digits
             .chars()
+            .rev()
             .map(|digit_char: char| digit_char.to_digit(10))
             .map(|digit_option: Option<u32>| digit_option.unwrap())
             .tuples::<(_, _, _)>()


### PR DESCRIPTION
I noticed one other minor discrepancy between the CLI output and my pen-and-paper process: the order of the lines.

Many seem to draw the lines of the hexagram from the bottom up.  It's hard to find a central authority on such questions of practice, but here is [Divination.com](https://divination.com/how-to-consult-the-i-ching/) and [another seemingly well-informed source](https://www.eclecticenergies.com/iching/introduction).

To remedy this, I reversed the order of the chars in the `-c` arg value before they get mapped to lines.